### PR TITLE
Fix Spotify Embeds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,19 +9,19 @@
       "version": "1.0.0",
       "dependencies": {
         "astro": "^2.9.6",
-        "autoprefixer": "^10.4.14",
+        "autoprefixer": "^10.4.16",
         "colorthief": "^2.4.0",
         "copy-text-to-clipboard": "^3.2.0",
         "dialog-polyfill": "^0.5.6",
         "dotenv": "^16.3.1",
         "entities": "^4.5.0",
         "image-size": "^1.0.2",
-        "luxon": "^3.3.0",
+        "luxon": "^3.4.3",
         "plaiceholder": "^3.0.0",
         "postcss-normalize": "^10.0.1",
-        "rimraf": "^5.0.1",
-        "sass": "^1.64.1",
-        "sharp": "^0.32.4"
+        "rimraf": "^5.0.5",
+        "sass": "^1.69.4",
+        "sharp": "^0.32.6"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1307,9 +1307,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.14",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.14.tgz",
-      "integrity": "sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==",
+      "version": "10.4.16",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.16.tgz",
+      "integrity": "sha512-7vd3UC6xKp0HLfua5IjZlcXvGAGy7cBAXTg2lyQ/8WpNhd6SiZ8Be+xm3FyBSYJx5GKcpRCzBh7RH4/0dnY+uQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -1318,12 +1318,16 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
-        "browserslist": "^4.21.5",
-        "caniuse-lite": "^1.0.30001464",
-        "fraction.js": "^4.2.0",
+        "browserslist": "^4.21.10",
+        "caniuse-lite": "^1.0.30001538",
+        "fraction.js": "^4.3.6",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
         "postcss-value-parser": "^4.2.0"
@@ -1539,9 +1543,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.9",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
-      "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
+      "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -1557,10 +1561,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001503",
-        "electron-to-chromium": "^1.4.431",
-        "node-releases": "^2.0.12",
-        "update-browserslist-db": "^1.0.11"
+        "caniuse-lite": "^1.0.30001541",
+        "electron-to-chromium": "^1.4.535",
+        "node-releases": "^2.0.13",
+        "update-browserslist-db": "^1.0.13"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1629,9 +1633,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001517",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001517.tgz",
-      "integrity": "sha512-Vdhm5S11DaFVLlyiKu4hiUTkpZu+y1KA/rZZqVQfOD5YdDT/eQKlkt7NaE0WGOFgX32diqt9MiP9CAiFeRklaA==",
+      "version": "1.0.30001553",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001553.tgz",
+      "integrity": "sha512-N0ttd6TrFfuqKNi+pMgWJTb9qrdJu4JSpgPFLe/lrD19ugC6fZgF0pUewRowDwzdDnb9V41mFcdlYgl/PyKf4A==",
       "funding": [
         {
           "type": "opencollective",
@@ -2163,9 +2167,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.477",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.477.tgz",
-      "integrity": "sha512-shUVy6Eawp33dFBFIoYbIwLHrX0IZ857AlH9ug2o4rvbWmpaCUdBpQ5Zw39HRrfzAFm4APJE9V+E2A/WB0YqJw=="
+      "version": "1.4.565",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.565.tgz",
+      "integrity": "sha512-XbMoT6yIvg2xzcbs5hCADi0dXBh4//En3oFXmtPX+jiyyiCTiM9DGFT2SLottjpEs9Z8Mh8SqahbR96MaHfuSg=="
     },
     "node_modules/emmet": {
       "version": "2.4.5",
@@ -2457,15 +2461,15 @@
       }
     },
     "node_modules/fraction.js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz",
-      "integrity": "sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
       "engines": {
         "node": "*"
       },
       "funding": {
         "type": "patreon",
-        "url": "https://www.patreon.com/infusion"
+        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/fs-constants": {
@@ -2547,18 +2551,18 @@
       "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="
     },
     "node_modules/glob": {
-      "version": "10.3.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.3.tgz",
-      "integrity": "sha512-92vPiMb/iqpmEgsOoIDvTjc50wf9CCCvMzsi6W0JLPeUKE8TWP1a73PgqSrqy7iAZxaSD1YdzU7QZR5LF51MJw==",
+      "version": "10.3.10",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
       "dependencies": {
         "foreground-child": "^3.1.0",
-        "jackspeak": "^2.0.3",
+        "jackspeak": "^2.3.5",
         "minimatch": "^9.0.1",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
         "path-scurry": "^1.10.1"
       },
       "bin": {
-        "glob": "dist/cjs/src/bin.js"
+        "glob": "dist/esm/bin.mjs"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -3070,9 +3074,9 @@
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
     },
     "node_modules/jackspeak": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.2.2.tgz",
-      "integrity": "sha512-mgNtVv4vUuaKA97yxUHoA3+FkuhtxkjdXEWOyB/N76fjy0FjezEt34oy3epBtvCvS+7DyKwqCFWx/oJLV5+kCg==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
+      "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -3284,9 +3288,9 @@
       }
     },
     "node_modules/luxon": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.3.0.tgz",
-      "integrity": "sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.3.tgz",
+      "integrity": "sha512-tFWBiv3h7z+T/tDaoxA8rqTxy1CHV6gHS//QdaH4pulbq/JuBSGgQspQQqcgnwdAx6pNI7cmvz5Sv/addzHmUg==",
       "engines": {
         "node": ">=12"
       }
@@ -4160,9 +4164,9 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.2.tgz",
-      "integrity": "sha512-eL79dXrE1q9dBbDCLg7xfn/vl7MS4F1gvJAgjJrQli/jbQWdUttuVawphqpffoIYfRdq78LHx6GP4bU/EQ2ATA==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
+      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -4525,9 +4529,9 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.0.tgz",
-      "integrity": "sha512-svTf/fzsKHffP42sujkO/Rjs37BCIsQVRCeNYIm9WN8rgT7ffoUnRtZCqU+6BqcSBdv8gwJeTz8knJpgACeQMw==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
+      "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
       "engines": {
         "node": "14 || >=16.14"
       }
@@ -5234,14 +5238,14 @@
       }
     },
     "node_modules/rimraf": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.1.tgz",
-      "integrity": "sha512-OfFZdwtd3lZ+XZzYP/6gTACubwFcHdLRqS9UX3UwpU2dnGQYkPFISRwvM3w9IiB2w7bW5qGo/uAwE4SmXXSKvg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.5.tgz",
+      "integrity": "sha512-CqDakW+hMe/Bz202FPEymy68P+G50RfMQK+Qo5YUqc9SPipvbGjCGKd0RSKEelbsfQuw3g5NZDSrlZZAJurH1A==",
       "dependencies": {
-        "glob": "^10.2.5"
+        "glob": "^10.3.7"
       },
       "bin": {
-        "rimraf": "dist/cjs/src/bin.js"
+        "rimraf": "dist/esm/bin.mjs"
       },
       "engines": {
         "node": ">=14"
@@ -5429,9 +5433,9 @@
       "integrity": "sha512-ZRwKbh/eQ6w9vmTjkuG0Ioi3HBwPFce0O+v//ve+aOq1oeCy7jMV2qzzAlpsNuqpqCBjjriM1lbtZbF/Q8jVyA=="
     },
     "node_modules/sass": {
-      "version": "1.64.1",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.64.1.tgz",
-      "integrity": "sha512-16rRACSOFEE8VN7SCgBu1MpYCyN7urj9At898tyzdXFhC+a+yOX5dXwAR7L8/IdPJ1NB8OYoXmD55DM30B2kEQ==",
+      "version": "1.69.4",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.69.4.tgz",
+      "integrity": "sha512-+qEreVhqAy8o++aQfCJwp0sklr2xyEzkm9Pp/Igu9wNPoe7EZEQ8X/MBvvXggI2ql607cxKg/RKOwDj6pp2XDA==",
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -5500,9 +5504,9 @@
       "integrity": "sha512-rb+9B5YBIEzYcD6x2VKidaa+cqYBJQKnU4oe4E3ANwRRN56yk/ua1YCJT1n21NTS8w6CcOclAKNP3PhdCXKYtQ=="
     },
     "node_modules/sharp": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.4.tgz",
-      "integrity": "sha512-exUnZewqVZC6UXqXuQ8fyJJv0M968feBi04jb9GcUHrWtkRoAKnbJt8IfwT4NJs7FskArbJ14JAFGVuooszoGg==",
+      "version": "0.32.6",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.6.tgz",
+      "integrity": "sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==",
       "hasInstallScript": true,
       "dependencies": {
         "color": "^4.2.3",
@@ -6210,9 +6214,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
-      "integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -16,18 +16,18 @@
   },
   "dependencies": {
     "astro": "^2.9.6",
-    "autoprefixer": "^10.4.14",
+    "autoprefixer": "^10.4.16",
     "colorthief": "^2.4.0",
     "copy-text-to-clipboard": "^3.2.0",
     "dialog-polyfill": "^0.5.6",
     "dotenv": "^16.3.1",
     "entities": "^4.5.0",
     "image-size": "^1.0.2",
-    "luxon": "^3.3.0",
+    "luxon": "^3.4.3",
     "plaiceholder": "^3.0.0",
     "postcss-normalize": "^10.0.1",
-    "rimraf": "^5.0.1",
-    "sass": "^1.64.1",
-    "sharp": "^0.32.4"
+    "rimraf": "^5.0.5",
+    "sass": "^1.69.4",
+    "sharp": "^0.32.6"
   }
 }

--- a/spotifySync.js
+++ b/spotifySync.js
@@ -88,6 +88,7 @@ async function processPlaylists(playlists) {
   for (const playlist of playlists) {
     // store plalist cover locally
     const coverImageData = await storePlaylistCover(playlist.images[0].url, playlist.id);
+    // get oEmbed data from api to store with playlist data
     const oembedData = await getSpotifyOembedData(playlist.external_urls.spotify);
     // regex for parsing release info from playlist name
     const nameRegex = playlist.name.match(/(TSL|BDP|BPD)(\d+)(?:.*?(\d{4}-\d{1,2}-\d{1,2}))?/);

--- a/spotifySync.js
+++ b/spotifySync.js
@@ -67,11 +67,28 @@ async function getSpotifyData(queryUrl, spotifyData = []) {
   .catch(error => { throw error });
 }
 
+// fetch oEmbed data from spotify api
+async function getSpotifyOembedData(playlistUrl) {
+  return await fetch(`https://open.spotify.com/oembed?url=${encodeURIComponent(playlistUrl)}`, {
+    method: 'GET',
+    headers: new Headers({
+      'Authorization': `Bearer ${accessToken}`,
+      'Content-Type': 'application/x-www-form-urlencoded'
+    }),
+  })
+  .then(response => response.json())
+  .then(data => {
+    return data;
+  })
+  .catch(error => { throw error });
+}
+
 // handle playlist processing
 async function processPlaylists(playlists) {
   for (const playlist of playlists) {
     // store plalist cover locally
     const coverImageData = await storePlaylistCover(playlist.images[0].url, playlist.id);
+    const oembedData = await getSpotifyOembedData(playlist.external_urls.spotify);
     // regex for parsing release info from playlist name
     const nameRegex = playlist.name.match(/(TSL|BDP|BPD)(\d+)(?:.*?(\d{4}-\d{1,2}-\d{1,2}))?/);
     // set up playlist data to be stored locally
@@ -93,6 +110,7 @@ async function processPlaylists(playlists) {
         colors: coverImageData.colors
       },
       owner: playlist.owner,
+      oembed: oembedData,
     }
     // write file to astro content collection
     const dataFilePath = path.join(path.resolve(), 'src', 'content', 'playlists', `${playlist.id}.json`);

--- a/src/components/PlaylistDetailsModal.astro
+++ b/src/components/PlaylistDetailsModal.astro
@@ -30,7 +30,9 @@ const secondaryColor = getHighestContrastColor(primaryColor, palette);
     <PlaylistCover releaseNum={playlist.release.number} playlistImg={playlist.image} />
     <Icon filename="waveline" />
     <h4>Preview</h4>
-    <Fragment set:html={playlist.oembed.html} />
+    <div class="spotify-embed" data-embed-src={playlist.oembed.iframe_url}>
+      <Icon filename="loader" />
+    </div>
   </div>
 </dialog>
 
@@ -215,5 +217,21 @@ h4 {
   line-height: 1.125em;
   font-weight: 800;
   margin: 1em 0;
+}
+
+.spotify-embed {
+  & > :global(svg) {
+    font-size: 2rem;
+  }
+
+  dialog[open] & > :global(svg) {
+    animation: spin 1s utils.$transition-in-out-cubic infinite;
+  }
+
+  &[data-init] {
+    & > :global(svg) {
+      display: none;
+    }
+  }
 }
 </style>

--- a/src/components/PlaylistDetailsModal.astro
+++ b/src/components/PlaylistDetailsModal.astro
@@ -30,7 +30,7 @@ const secondaryColor = getHighestContrastColor(primaryColor, palette);
     <PlaylistCover releaseNum={playlist.release.number} playlistImg={playlist.image} />
     <Icon filename="waveline" />
     <h4>Preview</h4>
-    <div class="spotify-embed" data-uri={playlist.uri}><Icon filename="loader" /></div>
+    <Fragment set:html={playlist.oembed.html} />
   </div>
 </dialog>
 
@@ -129,6 +129,10 @@ dialog {
   box-shadow: 0 0 6rem rgba(0, 0, 0, 0.86);
   text-align: center;
 
+  :global(iframe) {
+    height: 890px;
+  }
+
   dialog[open] & {
     animation: dialogIn 1s ease-in-out;
   }
@@ -211,15 +215,5 @@ h4 {
   line-height: 1.125em;
   font-weight: 800;
   margin: 1em 0;
-}
-
-.spotify-embed {
-  & > :global(svg) {
-    font-size: 2rem;
-  }
-
-  dialog[open] & > :global(svg) {
-    animation: spin 1s utils.$transition-in-out-cubic infinite;
-  }
 }
 </style>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -39,8 +39,6 @@ const secondaryColor = getHighestContrastColor(primaryColor, palette);
     <meta property="og:image:width" content={imageDimensions(socialImage).width?.toString()}>
     <meta property="og:image:height" content={imageDimensions(socialImage).height?.toString()}>
     <meta name="twitter:card" content="summary_large_image">
-
-    <script src="https://open.spotify.com/embed-podcast/iframe-api/v1" async></script>
 	</head>
 	<body>
 		<slot />
@@ -52,7 +50,6 @@ const secondaryColor = getHighestContrastColor(primaryColor, palette);
 window.openDetailsModal = (playlistId) => {
   const detailsModal = document.querySelector(`#playlist-details-${playlistId}`);
   const releaseNumber = detailsModal.dataset.release;
-  const spotifyEmbed = detailsModal.querySelector('.spotify-embed');
   // close other modal if open
   if (document.querySelector('[id^="playlist-details-"][open]')) document.querySelector('[id^="playlist-details-"][open]').close();
   // update history state
@@ -63,14 +60,6 @@ window.openDetailsModal = (playlistId) => {
   detailsModal.addEventListener('close', closeDetailsModal);
   // update site title
   document.title = `The Short List | Release #${releaseNumber}`;
-  // initialize spotify embed within modal
-  if (spotifyEmbed) {
-    const spotifyEmbedOptions = {
-      uri: spotifyEmbed.dataset.uri,
-      height: 890
-    };
-    window.SpotifyIframeApi.createController(spotifyEmbed, spotifyEmbedOptions, (EmbedController) => {});
-  }
 }
 
 // handle closing playlist details modal

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -50,6 +50,7 @@ const secondaryColor = getHighestContrastColor(primaryColor, palette);
 window.openDetailsModal = (playlistId) => {
   const detailsModal = document.querySelector(`#playlist-details-${playlistId}`);
   const releaseNumber = detailsModal.dataset.release;
+  const spotifyEmbed = detailsModal.querySelector('.spotify-embed');
   // close other modal if open
   if (document.querySelector('[id^="playlist-details-"][open]')) document.querySelector('[id^="playlist-details-"][open]').close();
   // update history state
@@ -60,6 +61,23 @@ window.openDetailsModal = (playlistId) => {
   detailsModal.addEventListener('close', closeDetailsModal);
   // update site title
   document.title = `The Short List | Release #${releaseNumber}`;
+  // initialize spotify embed within modal
+  if (spotifyEmbed) {
+    // return if embed has already been initialized
+    if (spotifyEmbed.getAttribute('data-init')) return;
+    // create embed element
+    const spotifyEmbedEl = document.createElement('iframe');
+    // set up embed element attributes
+    spotifyEmbedEl.src = spotifyEmbed.dataset.embedSrc;
+    spotifyEmbedEl.title = `Spotify Preview for The Short List Release #${releaseNumber}`;
+    spotifyEmbedEl.width = '100%';
+    spotifyEmbedEl.height = '890';
+    spotifyEmbedEl.setAttribute('frameborder', '0');
+    // append embed element to embed container
+    spotifyEmbed.appendChild(spotifyEmbedEl);
+    // mark embed as initialized to prevent further runs
+    spotifyEmbed.setAttribute('data-init', 'true');
+  }
 }
 
 // handle closing playlist details modal


### PR DESCRIPTION
The current implementation of the Spotify embeds was proving unreliable. This simplifies how they're handled. Instead of using the iframe API to generate the embeds, the iframe code/markup is now pulled from the oEmbed API and stored with the playlist data so that it can be used in the template.